### PR TITLE
ci: Fix ci-cherry-pick-source and automerge-pr

### DIFF
--- a/.github/workflows/ci-automerge-pr.yml
+++ b/.github/workflows/ci-automerge-pr.yml
@@ -26,6 +26,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_LABELS: 'automerge'
           MERGE_METHOD: 'squash'
-          MERGE_COMMIT_MESSAGE: 'pull-request-title-and-description'
+          # MERGE_COMMIT_MESSAGE: 'pull-request-title-and-description'
+          MERGE_COMMIT_MESSAGE: |
+            {pullRequest.title} (#{pullRequest.number})
+
+            {pullRequest.body}
           UPDATE_LABELS: 'automerge'
           UPDATE_METHOD: 'rebase'

--- a/.github/workflows/ci-cherry-pick-source.yml
+++ b/.github/workflows/ci-cherry-pick-source.yml
@@ -113,7 +113,7 @@ jobs:
         uses: carloscastrojumo/github-cherry-pick-action@v1.0
         with:
           branch: 'source/git-master'
-          labels: 'cherry-pick'
+          labels: 'cherry-pick, automerge'
           force: true
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Add 'automerge' label for PR created by ci-cherry-pick-source 
- Modify MERGE_COMMIT_MESSAGE in automerge-action